### PR TITLE
Create LANdiscovery.md

### DIFF
--- a/Informatics/Network/LANdiscovery.md
+++ b/Informatics/Network/LANdiscovery.md
@@ -16,9 +16,20 @@ Also, Win10 1709 added a SMB 1.0/CIFS Automatic Removal, so you can either unche
 ![image](https://user-images.githubusercontent.com/12049360/41858329-e0b7418e-7899-11e8-9242-16c710569cd6.png)
 
 
-Faut activer la ligne **SMB1.0 etc...**   
+You need to activate **SMB1.0 etc...**   
 
 ![image](https://user-images.githubusercontent.com/12049360/41859226-0541bad2-789c-11e8-8c72-6bfc495d6298.png)
 
-Et en fait,   
-c'est tout. Après redémarage, j'ai pu voir tout les ordis et le NAS connectés sur le réseau local. 
+And... that's it.  
+After reboot, I had all the network visible.  
+
+Pour les irréductibles utilisateur de windows en français.  
+La traduction est différente :  
+
+`Panneau de configuration > Programmes > Activer ou désactiver des fonctionnalités Windows`
+
+et il faut activer ceci: 
+
+![image](https://user-images.githubusercontent.com/25099826/42094104-003d3d20-7baf-11e8-9b9d-2c499e26fd83.png) 
+
+Merci @zuperninja pour la remarque. 

--- a/Informatics/Network/LANdiscovery.md
+++ b/Informatics/Network/LANdiscovery.md
@@ -1,0 +1,16 @@
+It seems that windows is a funny fellow and some windows10 computers cannot access to local network, for exemple to connect to the NAS.
+
+## Cause:
+Microsoft decided to uninstall old smb driver (samba). hahaha, thanks Bill. you're an ass****
+
+## Solution: 
+
+[Windows 10: Network Devices invisible after Windows Update to Build 16299.125](https://www.tenforums.com/network-sharing/101060-network-devices-invisible-after-windows-update-build-16299-125-a-2.html)
+
+> Depending on what SMB version your Netgear router uses (older ones use SMBv1), you need to check your Pro system and make sure SMBv1 is still installed ...   
+**Go to Control Panel > Program and Features > Turn Windows Features On or Off > SMB 1.0/CIFS File Sharing Support.**   
+Also, Win10 1709 added a SMB 1.0/CIFS Automatic Removal, so you can either uncheck the box or go to Task Scheduler > Microsoft > Windows > SMB and disable the 2 tasks it adds.
+
+> Note: I have an older Netgear WNDR4000 Router and use ReadyShare USB File Sharing. It uses SMBv1 (Server), so I have to have SMBv1 installed, but I only need the Client part.
+
+![image](https://user-images.githubusercontent.com/12049360/41858329-e0b7418e-7899-11e8-9242-16c710569cd6.png)

--- a/Informatics/Network/LANdiscovery.md
+++ b/Informatics/Network/LANdiscovery.md
@@ -14,3 +14,11 @@ Also, Win10 1709 added a SMB 1.0/CIFS Automatic Removal, so you can either unche
 > Note: I have an older Netgear WNDR4000 Router and use ReadyShare USB File Sharing. It uses SMBv1 (Server), so I have to have SMBv1 installed, but I only need the Client part.
 
 ![image](https://user-images.githubusercontent.com/12049360/41858329-e0b7418e-7899-11e8-9242-16c710569cd6.png)
+
+
+Faut activer la ligne **SMB1.0 etc...**   
+
+![image](https://user-images.githubusercontent.com/12049360/41859226-0541bad2-789c-11e8-8c72-6bfc495d6298.png)
+
+Et en fait,   
+c'est tout. Après redémarage, j'ai pu voir tout les ordis et le NAS connectés sur le réseau local. 


### PR DESCRIPTION
Résolution du bug #8 

J'ai trouvé une soluce en installant les drivers manquant par défaut. 
Je détaille la méthode et faudra tester chez les autres. 

C'est peut-être aussi en lien avec les problèmes de visibilité de l'imprimante réseau.... en fait.
@DewiBrunet 